### PR TITLE
Fix string escaping for single quotes

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -606,6 +606,9 @@ pub fn unescape_string(s: &str) -> String {
                 '\\' => {
                     s2.push('\\');
                 }
+                '\'' => {
+                    s2.push('\'');
+                }
                 _ => {
                     s2.push('\\');
                     s2.push(c);


### PR DESCRIPTION
Fixes #159

This PR adds support for escaped single quotes (\') in the unescape_string function.

## Problem
Previously, \' was being converted to literal \' instead of a single quote, causing "unrecognized escape sequence" errors in regex patterns.

## Solution
Added a specific case for single quote escaping in the unescape_string function (src/compiler.rs).

## Testing
This fix allows expressions like `[\'s m; not]` to work correctly by properly escaping single quotes within string literals.

Generated with [Claude Code](https://claude.ai/code)