### PR TITLE
fix: Make rpkiv.files work from arbitrary locations within cache

### DIFF
--- a/lib/rpkiv.ch
+++ b/lib/rpkiv.ch
@@ -216,6 +216,9 @@
     cwd; cwd var; cwd !;
     name var; name !;
     files var; files !;
+    # Convert file paths to absolute paths before changing directory
+    cwd @; orig_cwd var; orig_cwd !;
+    files @; [dup; / 0 get; 0 get; / =; not; if; orig_cwd @; swap; ++; then] map; files !;
     rpkiv._gsd; name @; ++; rsv var; rsv !;
     rsv @; cd;
     type f<; shift; chomp; rpki-client =; not; if;


### PR DESCRIPTION
Convert relative file paths to absolute paths before changing directory to validator storage directory. This allows rpkiv.files to work correctly regardless of the user's current working directory within the cache.

Fixes #150

Generated with [Claude Code](https://claude.ai/code)