### PR TITLE
feat: add support for >> append redirection in external commands

### DIFF
--- a/src/vm/vm_command.rs
+++ b/src/vm/vm_command.rs
@@ -18,19 +18,21 @@ use crate::chunk::{CommandGenerator, Value};
 use crate::vm::*;
 
 lazy_static! {
-    static ref START_DOUBLE_QUOTE:  Regex = Regex ::new(r#"^\s*""#).unwrap();
-    static ref END_DOUBLE_QUOTE:    Regex = Regex ::new(r#""\s*$"#).unwrap();
-    static ref START_SINGLE_QUOTE:  Regex = Regex ::new(r#"^\s*'"#).unwrap();
-    static ref END_SINGLE_QUOTE:    Regex = Regex ::new(r#"'\s*$"#).unwrap();
-    static ref END_SLASH_EXTRA:     Regex = Regex ::new(r#".*\\$"#).unwrap();
-    static ref END_SLASH:           Regex = Regex ::new(r#"\\$"#).unwrap();
-    static ref CAPTURE_NUM:         Regex = Regex ::new("\\{(\\d+)\\}").unwrap();
-    static ref CAPTURE_WITHOUT_NUM: Regex = Regex ::new("\\{\\}").unwrap();
-    static ref HOME_DIR_TILDE:      Regex = Regex ::new("\\s~").unwrap();
-    static ref LEADING_WS:          Regex = Regex ::new("^\\s*").unwrap();
-    static ref ENV_VAR:             Regex = Regex ::new("^(.*)=(.*)$").unwrap();
-    static ref STDOUT_REDIRECT:     Regex = Regex ::new("^1?>(.*)$").unwrap();
-    static ref STDERR_REDIRECT:     Regex = Regex ::new("^2>(.*)$").unwrap();
+    static ref START_DOUBLE_QUOTE:    Regex = Regex ::new(r#"^\s*""#).unwrap();
+    static ref END_DOUBLE_QUOTE:      Regex = Regex ::new(r#""\s*$"#).unwrap();
+    static ref START_SINGLE_QUOTE:    Regex = Regex ::new(r#"^\s*'"#).unwrap();
+    static ref END_SINGLE_QUOTE:      Regex = Regex ::new(r#"'\s*$"#).unwrap();
+    static ref END_SLASH_EXTRA:       Regex = Regex ::new(r#".*\\$"#).unwrap();
+    static ref END_SLASH:             Regex = Regex ::new(r#"\\$"#).unwrap();
+    static ref CAPTURE_NUM:           Regex = Regex ::new("\\{(\\d+)\\}").unwrap();
+    static ref CAPTURE_WITHOUT_NUM:   Regex = Regex ::new("\\{\\}").unwrap();
+    static ref HOME_DIR_TILDE:        Regex = Regex ::new("\\s~").unwrap();
+    static ref LEADING_WS:            Regex = Regex ::new("^\\s*").unwrap();
+    static ref ENV_VAR:               Regex = Regex ::new("^(.*)=(.*)$").unwrap();
+    static ref STDOUT_REDIRECT:       Regex = Regex ::new("^1?>(.*)$").unwrap();
+    static ref STDERR_REDIRECT:       Regex = Regex ::new("^2>(.*)$").unwrap();
+    static ref STDOUT_APPEND_REDIRECT: Regex = Regex ::new("^1?>>(.*)$").unwrap();
+    static ref STDERR_APPEND_REDIRECT: Regex = Regex ::new("^2>>(.*)$").unwrap();
 }
 
 /// Splits a string on whitespace, taking into account quoted values
@@ -49,7 +51,7 @@ fn split_command(s: &str) -> Option<VecDeque<String>> {
                 add_to_next_opt = None;
             }
             _ => {
-                if e_str == ">" || e_str == "2>" || e_str == "1>" {
+                if e_str == ">" || e_str == "2>" || e_str == "1>" || e_str == ">>" || e_str == "2>>" || e_str == "1>>" {
                     add_to_next_opt = Some(e_str);
                     continue;
                 }
@@ -167,8 +169,8 @@ impl VM {
                  Vec<String>,
                  HashMap<String, String>,
                  HashSet<String>,
-                 Option<String>,
-                 Option<String>)> {
+                 Option<(String, bool)>,
+                 Option<(String, bool)>)> {
         let prepared_cmd_opt = self.prepare_command(cmd);
         if prepared_cmd_opt.is_none() {
             return None;
@@ -215,21 +217,49 @@ impl VM {
             while !elements.is_empty() {
                 let len = elements.len();
                 let element = elements.get(len - 1).unwrap();
-                let mut captures = STDOUT_REDIRECT.captures_iter(element);
+                
+                // Check for stdout append redirect (>> or 1>>)
+                let mut captures = STDOUT_APPEND_REDIRECT.captures_iter(element);
                 match captures.next() {
                     Some(capture) => {
                         let output = capture.get(1).unwrap().as_str();
-                        stdout_redirect = Some(output.to_string());
+                        stdout_redirect = Some((output.to_string(), true));
                         elements.pop_back();
                         continue;
                     }
                     _ => {}
                 }
+                
+                // Check for stderr append redirect (2>>)
+                captures = STDERR_APPEND_REDIRECT.captures_iter(element);
+                match captures.next() {
+                    Some(capture) => {
+                        let output = capture.get(1).unwrap().as_str();
+                        stderr_redirect = Some((output.to_string(), true));
+                        elements.pop_back();
+                        continue;
+                    }
+                    _ => {}
+                }
+                
+                // Check for stdout regular redirect (> or 1>)
+                captures = STDOUT_REDIRECT.captures_iter(element);
+                match captures.next() {
+                    Some(capture) => {
+                        let output = capture.get(1).unwrap().as_str();
+                        stdout_redirect = Some((output.to_string(), false));
+                        elements.pop_back();
+                        continue;
+                    }
+                    _ => {}
+                }
+                
+                // Check for stderr regular redirect (2>)
                 captures = STDERR_REDIRECT.captures_iter(element);
                 match captures.next() {
                     Some(capture) => {
                         let output = capture.get(1).unwrap().as_str();
-                        stderr_redirect = Some(output.to_string());
+                        stderr_redirect = Some((output.to_string(), false));
                         elements.pop_back();
                         continue;
                     }
@@ -328,11 +358,18 @@ impl VM {
 
             let mut stdout_file_opt = None;
             let mut stdout_to_stderr = false;
-            if let Some(stdout_redirect) = stdout_redirect_opt {
+            if let Some((stdout_redirect, is_append)) = stdout_redirect_opt {
                 if stdout_redirect == "&2" {
                     stdout_to_stderr = true;
                 } else {
-                    let stdout_file_res = File::create(stdout_redirect);
+                    let stdout_file_res = if is_append {
+                        std::fs::File::options()
+                            .create(true)
+                            .append(true)
+                            .open(&stdout_redirect)
+                    } else {
+                        File::create(&stdout_redirect)
+                    };
                     match stdout_file_res {
                         Ok(stdout_file_arg) => {
                             stdout_file_opt = Some(stdout_file_arg.try_clone().unwrap());
@@ -349,11 +386,18 @@ impl VM {
 
             let mut stderr_file_opt = None;
             let mut stderr_to_stdout = false;
-            if let Some(stderr_redirect) = stderr_redirect_opt {
+            if let Some((stderr_redirect, is_append)) = stderr_redirect_opt {
                 if stderr_redirect == "&1" {
                     stderr_to_stdout = true;
                 } else {
-                    let stderr_file_res = File::create(stderr_redirect);
+                    let stderr_file_res = if is_append {
+                        std::fs::File::options()
+                            .create(true)
+                            .append(true)
+                            .open(&stderr_redirect)
+                    } else {
+                        File::create(&stderr_redirect)
+                    };
                     match stderr_file_res {
                         Ok(stderr_file_arg) => {
                             stderr_file_opt = Some(stderr_file_arg.try_clone().unwrap());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -19,6 +19,15 @@ fn add_file() {
     assert.success().stdout("3\n");
 }
 
+#[test]
+fn append_redirect_test() {
+    // Test >> append redirection for external commands
+    basic_test(
+        "first test_append_file f>; 'echo second >>test_append_file' exec; 'echo third >>test_append_file' exec; test_append_file f<; '' join; test_append_file rm;",
+        "firstsecond\nthird\n"
+    );
+}
+
 fn basic_test(input: &str, output: &str) {
     let mut file = NamedTempFile::new().unwrap();
     writeln!(file, "{}", input).unwrap();


### PR DESCRIPTION
Implements `>>` append redirection for external commands, similar to how `>` standard redirection currently works.

# Changes
- Add STDOUT_APPEND_REDIRECT and STDERR_APPEND_REDIRECT regexes to parse `>>` and `2>>` patterns
- Update split_command to handle `>>`, `2>>`, and `1>>` tokens
- Modify prepare_and_split_command to return (filename, is_append) tuples
- Update core_command_uncaptured to use File::options().create(true).append(true).open() for append mode
- Add comprehensive test for append redirection functionality

# Usage
- `>>file` or `1>>file` for stdout append
- `2>>file` for stderr append

Fixes #156

Generated with [Claude Code](https://claude.ai/code)