### PR TITLE
Fix string escaping for single quotes in regex patterns

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -606,6 +606,9 @@ pub fn unescape_string(s: &str) -> String {
                 '\\' => {
                     s2.push('\\');
                 }
+                '\'' => {
+                    s2.push('\'');
+                }
                 _ => {
                     s2.push('\\');
                     s2.push(c);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -958,6 +958,7 @@ impl VM {
         }
     }
 
+
     /// Takes a value, converts it into a string, and then generates a
     /// regex from that string and returns it.
     pub fn gen_regex(&mut self, value_rr: Value) -> Option<(Rc<Regex>, bool)> {
@@ -965,7 +966,9 @@ impl VM {
             if let Some(r) = &st.borrow().regex {
                 return Some(r.clone());
             }
-            let regex_res = self.str_to_regex(&st.borrow().escaped_string);
+            // Handle single quote escapes specifically for regex patterns
+            let regex_string = st.borrow().escaped_string.replace("\\'", "'");
+            let regex_res = self.str_to_regex(&regex_string);
             match regex_res {
                 Some((regex, global)) => {
                     let rc = Rc::new(regex);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2433,3 +2433,18 @@ fn rpsl_str_test() {
     // Test single element
     basic_test("lib/rpsl.ch import; (\"key\" \"value\") 1 mlist; rpsl.str; println", "key: value");
 }
+
+#[test]
+fn string_escape_single_quote_test() {
+    // Test basic single quote escaping
+    basic_test("\\' println", "'");
+    
+    // Test the specific command from issue #159
+    basic_test("\"asdf's\" \\'s m;", ".t");
+    
+    // Test single quote in regex pattern doesn't match
+    basic_test("\"asdf\" \\'s m;", ".f");
+    
+    // Test multiple escaped single quotes
+    basic_test("\\'test\\' println", "'test'");
+}


### PR DESCRIPTION
Fixes #159

This PR adds support for escaped single quotes (\') in regex patterns.

## Problem
Previously, \' was being passed directly to the regex engine, causing "unrecognized escape sequence" errors since \' is not a valid regex escape sequence.

## Solution
Implemented a targeted fix that:
- Added single quote escape handling in the `unescape_string` function
- Specifically handles \' in regex patterns by converting to literal single quotes
- Preserves all other regex escape sequences like \d, \n, etc.

## Testing
Added comprehensive tests including the specific command from the issue:
- `"asdf's" \'s m;` now correctly returns `.t`
- All existing regex tests continue to pass

Generated with [Claude Code](https://claude.ai/code)