### PR TITLE
feat: add support for >> append redirection in external commands

### DIFF
--- a/src/vm/vm_command.rs
+++ b/src/vm/vm_command.rs
@@ -218,27 +218,7 @@ impl VM {
             while !elements.is_empty() {
                 let len = elements.len();
                 let element = elements.get(len - 1).unwrap();
-                let mut captures = STDOUT_REDIRECT.captures_iter(element);
-                match captures.next() {
-                    Some(capture) => {
-                        let output = capture.get(1).unwrap().as_str();
-                        stdout_redirect = Some((output.to_string(), false));
-                        elements.pop_back();
-                        continue;
-                    }
-                    _ => {}
-                }
-                captures = STDERR_REDIRECT.captures_iter(element);
-                match captures.next() {
-                    Some(capture) => {
-                        let output = capture.get(1).unwrap().as_str();
-                        stderr_redirect = Some((output.to_string(), false));
-                        elements.pop_back();
-                        continue;
-                    }
-                    _ => {}
-                }
-                captures = STDOUT_APPEND_REDIRECT.captures_iter(element);
+                let mut captures = STDOUT_APPEND_REDIRECT.captures_iter(element);
                 match captures.next() {
                     Some(capture) => {
                         let output = capture.get(1).unwrap().as_str();
@@ -253,6 +233,26 @@ impl VM {
                     Some(capture) => {
                         let output = capture.get(1).unwrap().as_str();
                         stderr_redirect = Some((output.to_string(), true));
+                        elements.pop_back();
+                        continue;
+                    }
+                    _ => {}
+                }
+                captures = STDOUT_REDIRECT.captures_iter(element);
+                match captures.next() {
+                    Some(capture) => {
+                        let output = capture.get(1).unwrap().as_str();
+                        stdout_redirect = Some((output.to_string(), false));
+                        elements.pop_back();
+                        continue;
+                    }
+                    _ => {}
+                }
+                captures = STDERR_REDIRECT.captures_iter(element);
+                match captures.next() {
+                    Some(capture) => {
+                        let output = capture.get(1).unwrap().as_str();
+                        stderr_redirect = Some((output.to_string(), false));
                         elements.pop_back();
                         continue;
                     }

--- a/src/vm/vm_command.rs
+++ b/src/vm/vm_command.rs
@@ -31,6 +31,8 @@ lazy_static! {
     static ref ENV_VAR:             Regex = Regex ::new("^(.*)=(.*)$").unwrap();
     static ref STDOUT_REDIRECT:     Regex = Regex ::new("^1?>(.*)$").unwrap();
     static ref STDERR_REDIRECT:     Regex = Regex ::new("^2>(.*)$").unwrap();
+    static ref STDOUT_APPEND_REDIRECT: Regex = Regex ::new("^1?>>(.*)$").unwrap();
+    static ref STDERR_APPEND_REDIRECT: Regex = Regex ::new("^2>>(.*)$").unwrap();
 }
 
 /// Splits a string on whitespace, taking into account quoted values
@@ -49,7 +51,8 @@ fn split_command(s: &str) -> Option<VecDeque<String>> {
                 add_to_next_opt = None;
             }
             _ => {
-                if e_str == ">" || e_str == "2>" || e_str == "1>" {
+                if e_str == ">" || e_str == "2>" || e_str == "1>" ||
+                   e_str == ">>" || e_str == "2>>" || e_str == "1>>" {
                     add_to_next_opt = Some(e_str);
                     continue;
                 }
@@ -167,8 +170,8 @@ impl VM {
                  Vec<String>,
                  HashMap<String, String>,
                  HashSet<String>,
-                 Option<String>,
-                 Option<String>)> {
+                 Option<(String, bool)>,
+                 Option<(String, bool)>)> {
         let prepared_cmd_opt = self.prepare_command(cmd);
         if prepared_cmd_opt.is_none() {
             return None;
@@ -219,7 +222,7 @@ impl VM {
                 match captures.next() {
                     Some(capture) => {
                         let output = capture.get(1).unwrap().as_str();
-                        stdout_redirect = Some(output.to_string());
+                        stdout_redirect = Some((output.to_string(), false));
                         elements.pop_back();
                         continue;
                     }
@@ -229,7 +232,27 @@ impl VM {
                 match captures.next() {
                     Some(capture) => {
                         let output = capture.get(1).unwrap().as_str();
-                        stderr_redirect = Some(output.to_string());
+                        stderr_redirect = Some((output.to_string(), false));
+                        elements.pop_back();
+                        continue;
+                    }
+                    _ => {}
+                }
+                captures = STDOUT_APPEND_REDIRECT.captures_iter(element);
+                match captures.next() {
+                    Some(capture) => {
+                        let output = capture.get(1).unwrap().as_str();
+                        stdout_redirect = Some((output.to_string(), true));
+                        elements.pop_back();
+                        continue;
+                    }
+                    _ => {}
+                }
+                captures = STDERR_APPEND_REDIRECT.captures_iter(element);
+                match captures.next() {
+                    Some(capture) => {
+                        let output = capture.get(1).unwrap().as_str();
+                        stderr_redirect = Some((output.to_string(), true));
                         elements.pop_back();
                         continue;
                     }
@@ -328,11 +351,15 @@ impl VM {
 
             let mut stdout_file_opt = None;
             let mut stdout_to_stderr = false;
-            if let Some(stdout_redirect) = stdout_redirect_opt {
+            if let Some((stdout_redirect, is_append)) = stdout_redirect_opt {
                 if stdout_redirect == "&2" {
                     stdout_to_stderr = true;
                 } else {
-                    let stdout_file_res = File::create(stdout_redirect);
+                    let stdout_file_res = if is_append {
+                        File::options().create(true).append(true).open(stdout_redirect)
+                    } else {
+                        File::create(stdout_redirect)
+                    };
                     match stdout_file_res {
                         Ok(stdout_file_arg) => {
                             stdout_file_opt = Some(stdout_file_arg.try_clone().unwrap());
@@ -349,11 +376,15 @@ impl VM {
 
             let mut stderr_file_opt = None;
             let mut stderr_to_stdout = false;
-            if let Some(stderr_redirect) = stderr_redirect_opt {
+            if let Some((stderr_redirect, is_append)) = stderr_redirect_opt {
                 if stderr_redirect == "&1" {
                     stderr_to_stdout = true;
                 } else {
-                    let stderr_file_res = File::create(stderr_redirect);
+                    let stderr_file_res = if is_append {
+                        File::options().create(true).append(true).open(stderr_redirect)
+                    } else {
+                        File::create(stderr_redirect)
+                    };
                     match stderr_file_res {
                         Ok(stderr_file_arg) => {
                             stderr_file_opt = Some(stderr_file_arg.try_clone().unwrap());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2318,6 +2318,20 @@ fn redirect_test() {
 }
 
 #[test]
+fn append_redirect_test() {
+    // Test stdout append redirection with >>.
+    // Create a file, append to it, then check the results.
+    basic_test("'test' append_test f>; 'ls >>append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+    basic_test("'test' append_test f>; 'ls >> append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+    basic_test("'test' append_test f>; 'ls 1>>append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+    basic_test("'test' append_test f>; 'ls 1>> append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+
+    // Test stderr append redirection with 2>>.
+    basic_test("'test' append_test f>; 'ls notexists 2>>append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+    basic_test("'test' append_test f>; 'ls notexists 2>> append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+}
+
+#[test]
 fn hash_literal_test() {
     basic_error_test("h(1)", "1:5: expected even number of elements for hash");
     basic_error_test("h(h(1 2) 3)", "1:13: expected string for hash key");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2321,14 +2321,14 @@ fn redirect_test() {
 fn append_redirect_test() {
     // Test stdout append redirection with >>.
     // Create a file, append to it, then check the results.
-    basic_test("'test' append_test f>; 'ls >>append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
-    basic_test("'test' append_test f>; 'ls >> append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
-    basic_test("'test' append_test f>; 'ls 1>>append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
-    basic_test("'test' append_test f>; 'ls 1>> append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+    basic_test("'test\\n' append_test f>; 'ls -l >>append_test' exec; drop; append_test f<; len; . ls; len; 2 +; =; append_test rmf", ".t");
+    basic_test("'test\\n' append_test f>; 'ls -l >> append_test' exec; drop; append_test f<; len; . ls; len; 2 +; =; append_test rmf", ".t");
+    basic_test("'test\\n' append_test f>; 'ls -l 1>>append_test' exec; drop; append_test f<; len; . ls; len; 2 +; =; append_test rmf", ".t");
+    basic_test("'test\\n' append_test f>; 'ls -l 1>> append_test' exec; drop; append_test f<; len; . ls; len; 2 +; =; append_test rmf", ".t");
 
     // Test stderr append redirection with 2>>.
-    basic_test("'test' append_test f>; 'ls notexists 2>>append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
-    basic_test("'test' append_test f>; 'ls notexists 2>> append_test' exec; drop; append_test f<; len; 0 >; append_test rmf", ".t");
+    basic_test("'test\\n' append_test f>; 'ls notexists 2>>append_test' exec; drop; append_test f<; len; 2 =; append_test rmf", ".t");
+    basic_test("'test\\n' append_test f>; 'ls notexists 2>> append_test' exec; drop; append_test f<; len; 2 =; append_test rmf", ".t");
 }
 
 #[test]


### PR DESCRIPTION
Implements `>>` append redirection for external commands, similar to how `>` standard redirection currently works.

# Changes
- Add STDOUT_APPEND_REDIRECT and STDERR_APPEND_REDIRECT regexes to parse `>>` and `2>>` patterns
- Update split_command to handle `>>`, `2>>`, and `1>>` tokens
- Modify prepare_and_split_command to return (filename, is_append) tuples
- Update core_command_uncaptured to use File::options().create(true).append(true).open() for append mode
- Add comprehensive test for append redirection functionality

# Usage
- `>>file` or `1>>file` for stdout append
- `2>>file` for stderr append

Fixes #156

Generated with [Claude Code](https://claude.ai/code)